### PR TITLE
Add Laravel skeleton example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Migrating to Laravel with Blade
+
+If you want to recreate this project using Laravel for the backend and Blade for
+the frontend, an expanded example is provided in the `laravel-skeleton` directory.
+The skeleton now includes controllers and multiple Blade views demonstrating how the React pages can be translated to Blade.
+
+You will need PHP and Composer installed:
+
+```bash
+composer create-project laravel/laravel volunteer-metrics-pulse-laravel
+```
+
+After creating the project, copy the contents of `laravel-skeleton` into the corresponding folders of your Laravel application (`routes`, `resources`, and `app/Http/Controllers`).
+Run `php artisan serve` to view the pages. Expand the controllers and Blade templates to fully replicate the React functionality.
+

--- a/laravel-skeleton/README.md
+++ b/laravel-skeleton/README.md
@@ -1,0 +1,14 @@
+# Laravel Skeleton
+
+This folder shows a basic example of how you can port the Vite + React project to a Laravel application using Blade.
+
+## Setup
+1. Install PHP and Composer on your system.
+2. Create a new Laravel project:
+   ```bash
+   composer create-project laravel/laravel volunteer-metrics-pulse-laravel
+   ```
+3. Copy the contents of the `laravel-skeleton` directory into the new Laravel project. Place the `routes` and `resources` folders as well as the `app/Http/Controllers` files.
+4. Run `php artisan serve` to start the development server.
+
+The example controllers generate mock data similar to the React version and render it using Blade templates. Expand these templates and controllers to fully recreate the React UI and logic.

--- a/laravel-skeleton/app/Http/Controllers/DashboardController.php
+++ b/laravel-skeleton/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,97 @@
+<?php
+namespace App\Http\Controllers;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $pessoas = $this->generateMockPessoas(50);
+        $metrics = $this->calculateMetrics($pessoas);
+        return view('dashboard', ['metrics' => $metrics]);
+    }
+
+    private function generateMockPessoas(int $count = 50): array
+    {
+        $etapas = ['Prospecção','Primeiro Contato','Acompanhamento','Inclusão','Discipulado','Liderança','Batizado'];
+        $nomes = ['João Silva','Maria Santos','Pedro Costa','Ana Oliveira','Carlos Mendes','Lucia Ferreira','Roberto Lima','Fernanda Souza','Diego Alves','Patricia Rocha','Ricardo Martins','Juliana Castro','Marcos Pereira','Camila Dias','Felipe Torres','Beatriz Gomes','André Cardoso','Leticia Barbosa','Thiago Nascimento','Natalia Pires'];
+        $responsaveis = ['Pastor João','Líder Maria','Diácono Pedro','Irmã Ana','Presbítero Carlos'];
+        $pessoas = [];
+        $hoje = new \DateTime();
+        for ($i = 0; $i < $count; $i++) {
+            $nome = $nomes[array_rand($nomes)] . ' ' . ($i + 1);
+            $primeiroContato = (clone $hoje)->modify('-'.rand(0,365).' days');
+            $etapa = $etapas[array_rand($etapas)];
+            $dataBatismo = null;
+            $dataInclusao = null;
+            $dataLideranca = null;
+            if ($etapa === 'Batizado') {
+                $dataBatismo = (clone $primeiroContato)->modify('+'.rand(0,180).' days');
+            }
+            if (in_array($etapa, ['Inclusão','Discipulado','Liderança','Batizado'])) {
+                $dataInclusao = (clone $primeiroContato)->modify('+'.rand(0,90).' days');
+            }
+            if ($etapa === 'Liderança') {
+                $dataLideranca = (clone $dataInclusao ?: $primeiroContato)->modify('+'.rand(0,120).' days');
+            }
+            $pessoas[] = [
+                'id' => 'pessoa-'.($i+1),
+                'nome' => $nome,
+                'email' => strtolower(str_replace(' ', '.', $nome)).'@email.com',
+                'telefone' => '(11) 9'.rand(10000000,99999999),
+                'etapa' => $etapa,
+                'primeiroContato' => $primeiroContato,
+                'ultimaAtualizacao' => (clone $primeiroContato)->modify('+'.rand(0,30).' days'),
+                'dataBatismo' => $dataBatismo,
+                'isVoluntario' => rand(0,1) > 0.7,
+                'dataInclusao' => $dataInclusao,
+                'dataLideranca' => $dataLideranca,
+                'responsavel' => $responsaveis[array_rand($responsaveis)],
+            ];
+        }
+        return $pessoas;
+    }
+
+    private function calculateMetrics(array $pessoas): array
+    {
+        $hoje = new \DateTime();
+        $inicioMes = new \DateTime($hoje->format('Y-m-01'));
+        $visitantesMes = 0;
+        $batizados = 0;
+        $voluntariosAtivos = 0;
+        $prospeccao = 0;
+        $incluidos = 0;
+        $diasProspeccaoInclusao = 0;
+        $countProspeccaoInclusao = 0;
+        $diasInclusaoLideranca = 0;
+        $countInclusaoLideranca = 0;
+
+        foreach ($pessoas as $p) {
+            if ($p['primeiroContato'] >= $inicioMes) $visitantesMes++;
+            if ($p['dataBatismo']) $batizados++;
+            if ($p['isVoluntario']) $voluntariosAtivos++;
+            if ($p['etapa'] === 'Prospecção') $prospeccao++;
+            if ($p['dataInclusao']) {
+                $incluidos++;
+                $diasProspeccaoInclusao += $p['dataInclusao']->diff($p['primeiroContato'])->days;
+                $countProspeccaoInclusao++;
+            }
+            if ($p['dataLideranca']) {
+                if ($p['dataInclusao']) {
+                    $diasInclusaoLideranca += $p['dataLideranca']->diff($p['dataInclusao'])->days;
+                    $countInclusaoLideranca++;
+                }
+            }
+        }
+        $total = count($pessoas);
+        return [
+            'visitantes_mes' => $visitantesMes,
+            'taxa_batismo' => $total > 0 ? ($batizados / $total) * 100 : 0,
+            'tempo_medio_etapa' => 15,
+            'voluntarios_ativos' => $voluntariosAtivos,
+            'conversao_prospeccao_inclusao' => ($prospeccao + $incluidos) > 0 ? ($incluidos / ($prospeccao + $incluidos)) * 100 : 0,
+            'tempo_medio_prospeccao_inclusao' => $countProspeccaoInclusao > 0 ? $diasProspeccaoInclusao / $countProspeccaoInclusao : 0,
+            'tempo_medio_inclusao_lideranca' => $countInclusaoLideranca > 0 ? $diasInclusaoLideranca / $countInclusaoLideranca : 0,
+        ];
+    }
+}

--- a/laravel-skeleton/app/Http/Controllers/KanbanController.php
+++ b/laravel-skeleton/app/Http/Controllers/KanbanController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers;
+
+class KanbanController extends Controller
+{
+    public function index()
+    {
+        return view('kanban');
+    }
+}

--- a/laravel-skeleton/app/Http/Controllers/ProspeccaoController.php
+++ b/laravel-skeleton/app/Http/Controllers/ProspeccaoController.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Http\Controllers;
+
+class ProspeccaoController extends Controller
+{
+    public function index()
+    {
+        return view('prospeccao');
+    }
+}

--- a/laravel-skeleton/resources/views/components/navigation.blade.php
+++ b/laravel-skeleton/resources/views/components/navigation.blade.php
@@ -1,0 +1,20 @@
+<nav class="bg-white border-b border-gray-200 px-4 py-3 mb-4">
+    <div class="flex items-center justify-between max-w-7xl mx-auto">
+        <div class="flex items-center space-x-8">
+            <div class="text-xl font-bold text-primary">
+                Igreja Manager
+            </div>
+            <div class="flex space-x-4">
+                <a href="{{ route('dashboard') }}" class="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors {{ request()->routeIs('dashboard') ? 'bg-primary text-primary-foreground' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100' }}">
+                    <span>Dashboard</span>
+                </a>
+                <a href="{{ route('kanban') }}" class="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors {{ request()->routeIs('kanban') ? 'bg-primary text-primary-foreground' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100' }}">
+                    <span>Kanban</span>
+                </a>
+                <a href="{{ route('prospeccao') }}" class="flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-colors {{ request()->routeIs('prospeccao') ? 'bg-primary text-primary-foreground' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100' }}">
+                    <span>Prospecção</span>
+                </a>
+            </div>
+        </div>
+    </div>
+</nav>

--- a/laravel-skeleton/resources/views/dashboard.blade.php
+++ b/laravel-skeleton/resources/views/dashboard.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+<x-navigation />
+<h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="bg-white p-4 rounded shadow">
+        <h2 class="font-semibold mb-2">Visitantes este mês</h2>
+        <p>{{ $metrics['visitantes_mes'] }}</p>
+    </div>
+    <div class="bg-white p-4 rounded shadow">
+        <h2 class="font-semibold mb-2">Taxa de Batismo</h2>
+        <p>{{ number_format($metrics['taxa_batismo'], 2) }}%</p>
+    </div>
+    <div class="bg-white p-4 rounded shadow">
+        <h2 class="font-semibold mb-2">Voluntários Ativos</h2>
+        <p>{{ $metrics['voluntarios_ativos'] }}</p>
+    </div>
+</div>
+@endsection

--- a/laravel-skeleton/resources/views/kanban.blade.php
+++ b/laravel-skeleton/resources/views/kanban.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('content')
+<x-navigation />
+<h1 class="text-2xl font-bold mb-4">Kanban</h1>
+<p>Esta é uma página de exemplo para o quadro Kanban. Reimplemente o layout do React aqui usando Blade.</p>
+@endsection

--- a/laravel-skeleton/resources/views/layouts/app.blade.php
+++ b/laravel-skeleton/resources/views/layouts/app.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ config('app.name', 'Volunteer Metrics Pulse') }}</title>
+    @vite('resources/css/app.css')
+</head>
+<body class="font-sans antialiased">
+    <div class="container mx-auto p-4">
+        @yield('content')
+    </div>
+</body>
+</html>

--- a/laravel-skeleton/resources/views/prospeccao.blade.php
+++ b/laravel-skeleton/resources/views/prospeccao.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('content')
+<x-navigation />
+<h1 class="text-2xl font-bold mb-4">Prospecção</h1>
+<p>Página de prospecção para migrar os componentes de React para Blade.</p>
+@endsection

--- a/laravel-skeleton/resources/views/welcome.blade.php
+++ b/laravel-skeleton/resources/views/welcome.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Volunteer Metrics Pulse</h1>
+<p>Welcome to the Laravel version of the app. Replace this content with Blade components that mirror the React UI.</p>
+@endsection

--- a/laravel-skeleton/routes/web.php
+++ b/laravel-skeleton/routes/web.php
@@ -1,0 +1,13 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\KanbanController;
+use App\Http\Controllers\ProspeccaoController;
+
+Route::get('/', function () {
+    return view('welcome');
+})->name('home');
+
+Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
+Route::get('/kanban', [KanbanController::class, 'index'])->name('kanban');
+Route::get('/prospeccao', [ProspeccaoController::class, 'index'])->name('prospeccao');


### PR DESCRIPTION
## Summary
- add minimal Laravel skeleton with Blade templates
- document how to migrate to Laravel using Blade
- add controllers and Blade views for dashboard, kanban and prospecção

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6b85361883209aa4901bdfdbf305